### PR TITLE
WantHTTP available in QEMU

### DIFF
--- a/recipes/golang/wantgo/runtests.go
+++ b/recipes/golang/wantgo/runtests.go
@@ -154,7 +154,7 @@ func RunTests(jc wantjob.Ctx, src cadata.Getter, x RunTestsTask) (*glfs.Ref, err
 			return nil, err
 		}
 		var outRef glfs.Ref
-		if err := json.Unmarshal(res.Data, &outRef); err != nil {
+		if err := json.Unmarshal(res.Root, &outRef); err != nil {
 			return nil, err
 		}
 		if err := glfs.Sync(jc.Context, jc.Dst, outStore, outRef); err != nil {
@@ -204,7 +204,7 @@ func makeAllTestExecs(jc wantjob.Ctx, src cadata.Getter, x RunTestsTask) (map[st
 			return nil, err
 		}
 		var outRef glfs.Ref
-		if err := json.Unmarshal(res.Data, &outRef); err != nil {
+		if err := json.Unmarshal(res.Root, &outRef); err != nil {
 			return nil, err
 		}
 		if err := glfs.Sync(jc.Context, jc.Dst, outStore, outRef); err != nil {

--- a/recipes/golang/wantgo/wantgo_test.go
+++ b/recipes/golang/wantgo/wantgo_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"blobcache.io/glfs"
@@ -42,6 +43,9 @@ func TestPostGetRunTestsTask(t *testing.T) {
 }
 
 func TestRunTests(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.SkipNow()
+	}
 	jc := newJobCtx(t)
 	s := jc.Dst
 	bzImage := loadKernel(t)

--- a/recipes/qemu/qemu.libsonnet
+++ b/recipes/qemu/qemu.libsonnet
@@ -6,11 +6,16 @@ local virtiofs(root, writeable) =
 local output_virtiofs(fsid, q) = 
     {"virtiofs": {"id": fsid, "query": q}};
 
-local amd64_microvm(cores, memory, kernel, kargs, initrd=null, virtiofs={}, output=null) =
+local serialport_console() = {"console": {}};
+
+local serialport_wanthttp() = {"wanthttp": {}};
+
+local amd64_microvm(cores, memory, kernel, kargs, initrd=null, serial_ports=[serialport_console()], virtiofs={}, output=null) =
     local config = want.blob(std.manifestJsonEx({
         "cores": cores,
         "memory": memory,
         "kernel_args": kargs,
+        "serial_ports": serial_ports,
         "virtiofs": virtiofs,
         "output": output,
     }, ""));

--- a/src/internal/glfstasks/glfstasks.go
+++ b/src/internal/glfstasks/glfstasks.go
@@ -27,7 +27,7 @@ func Do(ctx context.Context, sys wantjob.System, src cadata.Getter, op wantjob.O
 	if err := out.Err(); err != nil {
 		return nil, nil, err
 	}
-	ref, err := ParseGLFSRef(out.Data)
+	ref, err := ParseGLFSRef(out.Root)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +45,7 @@ func Exec(x []byte, fn func(x glfs.Ref) (*glfs.Ref, error)) wantjob.Result {
 	}
 	return wantjob.Result{
 		Schema: wantjob.Schema_GLFS,
-		Data:   MarshalGLFSRef(*out),
+		Root:   MarshalGLFSRef(*out),
 	}
 }
 
@@ -66,7 +66,7 @@ func MarshalGLFSRef(x glfs.Ref) []byte {
 }
 
 func Success(x glfs.Ref) *wantjob.Result {
-	return &wantjob.Result{Data: MarshalGLFSRef(x)}
+	return &wantjob.Result{Root: MarshalGLFSRef(x)}
 }
 
 func FastSync(ctx context.Context, dst cadata.PostExister, src cadata.Getter, root glfs.Ref) error {

--- a/src/internal/nnc/nnc_test.go
+++ b/src/internal/nnc/nnc_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package nnc
 
 import (

--- a/src/internal/op/dagops/dagops.go
+++ b/src/internal/op/dagops/dagops.go
@@ -41,5 +41,5 @@ func (e Executor) ExecLast(jc wantjob.Ctx, s cadata.Getter, ref glfs.Ref) (*glfs
 	if err := res.Err(); err != nil {
 		return nil, err
 	}
-	return glfstasks.ParseGLFSRef(res.Data)
+	return glfstasks.ParseGLFSRef(res.Root)
 }

--- a/src/internal/op/goops/download.go
+++ b/src/internal/op/goops/download.go
@@ -38,7 +38,7 @@ func (e *Executor) ModDownload(jc wantjob.Ctx, s cadata.Getter, x glfs.Ref) (*gl
 		GOOS:       runtime.GOARCH,
 		GOARCH:     runtime.GOOS,
 		GOPROXY:    "direct",
-		GOMODCACHE: filepath.Join(e.installDir, "gomodcache"),
+		GOMODCACHE: filepath.Join(e.scratchDir, "gomodcache"),
 	}, "mod", "download", "-x")
 	cmd1.Dir = filepath.Join(dir, "in")
 	cmd1.Stdout = jc.Writer("stdout")
@@ -55,7 +55,7 @@ func (e *Executor) ModDownload(jc wantjob.Ctx, s cadata.Getter, x glfs.Ref) (*gl
 		GOARCH: runtime.GOOS,
 
 		GOMODCACHE: filepath.Join(dir, "modcache"),
-		GOPROXY:    fmt.Sprintf("file:///%s", filepath.Join(e.installDir, "gomodcache", "cache", "download")),
+		GOPROXY:    fmt.Sprintf("file:///%s", filepath.Join(e.scratchDir, "gomodcache", "cache", "download")),
 	}, "mod", "download", "-x")
 	cmd2.Dir = filepath.Join(dir, "in")
 	cmd2.Stdout = jc.Writer("stdout")

--- a/src/internal/op/goops/executor.go
+++ b/src/internal/op/goops/executor.go
@@ -31,13 +31,15 @@ const (
 var _ wantjob.Executor = &Executor{}
 
 type Executor struct {
-	installDir string
+	goRoot     string
+	scratchDir string
 	buildSem   *semaphore.Weighted
 }
 
-func NewExecutor(installDir string) *Executor {
+func NewExecutor(goRoot string, scratchDir string) *Executor {
 	return &Executor{
-		installDir: installDir,
+		goRoot:     goRoot,
+		scratchDir: scratchDir,
 		buildSem:   semaphore.NewWeighted(int64(runtime.GOMAXPROCS(0))),
 	}
 }
@@ -82,7 +84,7 @@ type goConfig struct {
 }
 
 func (e *Executor) newCommand(ctx context.Context, cfg goConfig, args ...string) *exec.Cmd {
-	goRoot := e.installDir
+	goRoot := e.goRoot
 	cmd := exec.CommandContext(ctx, filepath.Join(goRoot, "bin", "go"), args...)
 	cmd.Env = []string{
 		"PATH=/usr/bin/",
@@ -90,8 +92,6 @@ func (e *Executor) newCommand(ctx context.Context, cfg goConfig, args ...string)
 		"GOSUMDB=off",
 
 		"GOROOT=" + goRoot,
-		"GOPATH=" + filepath.Join(e.installDir, "gopath"),
-		//"GOCACHE=" + filepath.Join(e.installDir, "gocache"),
 
 		"GOARCH=" + cfg.GOARCH,
 		"GOOS=" + cfg.GOOS,

--- a/src/internal/op/goops/make_test_exec.go
+++ b/src/internal/op/goops/make_test_exec.go
@@ -91,7 +91,7 @@ func (e *Executor) MakeTestExec(jc wantjob.Ctx, src cadata.Getter, task MakeTest
 		if !filepath.IsLocal(task.Path) {
 			return nil, fmt.Errorf("entry path is not local %s", task.Path)
 		}
-		entryPath = filepath.Join(inPath, task.Path)
+		entryPath = "./" + task.Path
 	}
 
 	// setup module

--- a/src/internal/op/goops/setup.jsonnet
+++ b/src/internal/op/goops/setup.jsonnet
@@ -2,6 +2,7 @@ local want = import "@want";
 
 local hashes = {
     "amd64-linux": "6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971",
+    "arm64-darwin": "87d2bb0ad4fe24d2a0685a55df321e0efe4296419a9b3de03369dbe60b8acd3a",
 };
 
 local goDist(goVersion, goos, goarch) =

--- a/src/internal/op/importops/import_oci.go
+++ b/src/internal/op/importops/import_oci.go
@@ -9,7 +9,6 @@ import (
 
 	"blobcache.io/glfs"
 	"blobcache.io/glfs/glfstar"
-	"github.com/google/go-containerregistry/pkg/authn"
 	crname "github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -43,7 +42,7 @@ func (e *Executor) ImportOCIImage(jc wantjob.Ctx, s cadata.Getter, task ImportOC
 	if err != nil {
 		return nil, err
 	}
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	img, err := remote.Image(ref)
 	if err != nil {
 		return nil, fmt.Errorf("reading image failed: %w", err)
 	}
@@ -73,7 +72,7 @@ func (e *Executor) ImportOCIManifest(ctx context.Context, _ *wantjob.Ctx, s cada
 		return nil, err
 	}
 	// Create an anonymous (unauthenticated) client
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	img, err := remote.Image(ref)
 	if err != nil {
 		return nil, fmt.Errorf("reading image failed: %w", err)
 	}
@@ -97,7 +96,7 @@ func (e *Executor) ImportOCILayer(jc *wantjob.Ctx, dst cadata.Store, s cadata.Ge
 	if err != nil {
 		return nil, err
 	}
-	layer, err := remote.Layer(dig, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	layer, err := remote.Layer(dig)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/op/qemuops/qemu_test.go
+++ b/src/internal/op/qemuops/qemu_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"blobcache.io/glfs"
@@ -81,7 +82,7 @@ func TestConfigArgs(t *testing.T) {
 
 func TestInstall(t *testing.T) {
 	ctx := testutil.Context(t)
-	t.SkipNow()
+	//t.SkipNow()
 
 	outDir := t.TempDir()
 	jsys := wantjob.NewMem(ctx, wantsetup.NewExecutor())
@@ -146,6 +147,10 @@ func TestMicroVM(t *testing.T) {
 	for i, tc := range tcs {
 		tc := tc
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			if runtime.GOOS == "darwin" && tc.Task.VirtioFS != nil {
+				t.SkipNow()
+			}
+
 			out, err := e.amd64MicroVM(jc, s, tc.Task)
 			t.Log(out)
 			if tc.Err != nil {

--- a/src/internal/op/qemuops/setup.jsonnet
+++ b/src/internal/op/qemuops/setup.jsonnet
@@ -13,6 +13,7 @@ local virtiofsds = {
         hash="124acbe163b1dfe62fcfde96b7145f0b6046521ec836fc6134f6a9cde0c2e170",
 		transforms=["unzip"],
     ), "target/x86_64-unknown-linux-musl/release/virtiofsd"),
+    "arm64-darwin": want.blob(""),
 };
 
 local virtiofsd(arch, os) =
@@ -29,7 +30,11 @@ local qemuSystem_X86_64s = {
 
 local qemuSystem_X86_64(arch, os) =
     local key = arch + "-" + os;
-    qemuSystem_X86_64s[key];
+    if os == "darwin" then
+        want.blob('#!/bin/sh
+        exec qemu-system-x86_64 "$@"')
+    else
+        qemuSystem_X86_64s[key];
 
 want.pass([
    	want.input("share/qboot.rom", qbootRom),

--- a/src/internal/op/qemuops/testdata/passthrough/passthrough.go
+++ b/src/internal/op/qemuops/testdata/passthrough/passthrough.go
@@ -7,7 +7,7 @@ import (
 
 	"go.brendoncarroll.net/state/cadata"
 	"wantbuild.io/want/src/wantjob"
-	"wantbuild.io/want/src/wantqemu"
+	"wantbuild.io/want/src/wantjob/wanthttp"
 )
 
 func main() {
@@ -19,7 +19,7 @@ func main() {
 		panic(err)
 	}
 	defer f.Close()
-	wantqemu.MainRW(f, func(jc wantjob.Ctx, s cadata.Getter, root []byte) wantjob.Result {
+	wanthttp.MainRW(f, func(jc wantjob.Ctx, s cadata.Getter, root []byte) wantjob.Result {
 		return wantjob.Result{
 			ErrCode: wantjob.OK,
 			Schema:  wantjob.Schema_NoRefs,

--- a/src/internal/op/qemuops/testdata/passthrough/passthrough.go
+++ b/src/internal/op/qemuops/testdata/passthrough/passthrough.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+	"os"
+	"syscall"
+
+	"go.brendoncarroll.net/state/cadata"
+	"wantbuild.io/want/src/wantjob"
+	"wantbuild.io/want/src/wantqemu"
+)
+
+func main() {
+	if err := syscall.Mount("devtmpfs", "/dev", "devtmpfs", syscall.MS_NOSUID, "mode=0755"); err != nil {
+		log.Fatalf("Failed to mount devfs: %v", err)
+	}
+	f, err := os.OpenFile("/dev/vport0p1", os.O_RDWR, 0o644)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	wantqemu.MainRW(f, func(jc wantjob.Ctx, s cadata.Getter, root []byte) wantjob.Result {
+		return wantjob.Result{
+			ErrCode: wantjob.OK,
+			Schema:  wantjob.Schema_NoRefs,
+			Root:    root,
+		}
+	})
+}

--- a/src/internal/op/qemuops/testdata/writetoserial/writetoserial.go
+++ b/src/internal/op/qemuops/testdata/writetoserial/writetoserial.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+)
+
+func main() {
+	// Mount devfs at /dev
+	if err := syscall.Mount("devtmpfs", "/dev", "devtmpfs", syscall.MS_NOSUID, "mode=0755"); err != nil {
+		log.Fatalf("Failed to mount devfs: %v", err)
+	}
+	fmt.Println("Successfully mounted devfs at /dev")
+
+	// Read and print contents of /dev
+	entries, err := os.ReadDir("/dev")
+	if err != nil {
+		log.Fatalf("Failed to read /dev directory: %v", err)
+	}
+
+	fmt.Println("\nContents of /dev")
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			fmt.Printf("- %s (failed to get info: %v)\n", entry.Name(), err)
+			continue
+		}
+		fmt.Printf("- %s (mode: %v, size: %d bytes)\n", entry.Name(), info.Mode(), info.Size())
+	}
+
+	f, err := os.OpenFile("/dev/vport0p1", os.O_RDWR, 0o644)
+	if err != nil {
+		log.Fatalf("failed to open /dev/vport0p1: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte("hello world")); err != nil {
+		log.Fatalf("failed to write to /dev/vport0p1: %v", err)
+	}
+	fmt.Println("Successfully wrote to /dev/vport0p1")
+}

--- a/src/internal/op/qemuops/vm.go
+++ b/src/internal/op/qemuops/vm.go
@@ -38,7 +38,7 @@ func (e *Executor) newVM(jc wantjob.Ctx, dir string, vmcfg vmConfig) *vm {
 	}
 	jc.Infof("vm dir: %s", dir)
 
-	machineArg := "microvm,rtc=off,acpi=off,pic=off,isa-serial=off"
+	machineArg := "microvm,x-option-roms=off,rtc=off,acpi=off,pic=off,isa-serial=off"
 	if runtime.GOOS != "darwin" {
 		// pit=off seems to break something on darwin, the boot hangs
 		machineArg += ",pit=off"

--- a/src/internal/op/qemuops/vm.go
+++ b/src/internal/op/qemuops/vm.go
@@ -38,10 +38,15 @@ func (e *Executor) newVM(jc wantjob.Ctx, dir string, vmcfg vmConfig) *vm {
 	}
 	jc.Infof("vm dir: %s", dir)
 
+	machineArg := "microvm,rtc=off,acpi=off,pic=off,isa-serial=off"
+	if runtime.GOOS != "darwin" {
+		// pit=off seems to break something on darwin, the boot hangs
+		machineArg += ",pit=off"
+	}
 	// qemu
 	qemuCmd := func() *exec.Cmd {
 		args := []string{
-			"-M", "microvm,x-option-roms=off,rtc=off,acpi=off,pit=off,pic=off,isa-serial=off",
+			"-M", machineArg,
 			"-m", strconv.FormatUint(vmcfg.Memory/1e6, 10) + "M",
 			"-smp", strconv.FormatUint(uint64(vmcfg.NumCPUs), 10),
 			"-L", filepath.Join(e.cfg.InstallDir, "share"),

--- a/src/internal/op/wantops/build.go
+++ b/src/internal/op/wantops/build.go
@@ -64,7 +64,7 @@ func (e *Executor) Build(jc wantjob.Ctx, src cadata.Getter, buildTask BuildTask)
 					return err
 				}
 				errorsOccured = errorsOccured || res.ErrCode > 0
-				if ref, err := glfstasks.ParseGLFSRef(res.Data); err == nil {
+				if ref, err := glfstasks.ParseGLFSRef(res.Root); err == nil {
 					if err := glfstasks.FastSync(ctx, jc.Dst, dagStore, *ref); err != nil {
 						return err
 					}
@@ -84,7 +84,7 @@ func (e *Executor) Build(jc wantjob.Ctx, src cadata.Getter, buildTask BuildTask)
 	}
 	layers := []glfs.Ref{*groundRef}
 	for i := range targets {
-		if ref, err := glfstasks.ParseGLFSRef(results[i].Data); err == nil {
+		if ref, err := glfstasks.ParseGLFSRef(results[i].Root); err == nil {
 			layers = append(layers, *ref)
 		}
 	}

--- a/src/internal/wantdag/parallelexec.go
+++ b/src/internal/wantdag/parallelexec.go
@@ -52,7 +52,7 @@ func ParallelExecLast(jc wantjob.Ctx, src cadata.Getter, x DAG) (*wantjob.Result
 			if err := res.Err(); err != nil {
 				jc.Errorf("error in node %v %v %v", id, node.Op, err)
 			}
-			if ref, err := glfstasks.ParseGLFSRef(res.Data); err == nil {
+			if ref, err := glfstasks.ParseGLFSRef(res.Root); err == nil {
 				outRef = ref
 			}
 			union = append(union, outSrc)

--- a/src/internal/wantdag/serialexec.go
+++ b/src/internal/wantdag/serialexec.go
@@ -56,7 +56,7 @@ func SerialExecAll(jc wantjob.Ctx, s cadata.Getter, x DAG) ([]wantjob.Result, er
 			}
 			nodeResults[i] = *out
 			nodeStores[i] = outSrc
-			outRef, _ = glfstasks.ParseGLFSRef(out.Data)
+			outRef, _ = glfstasks.ParseGLFSRef(out.Root)
 		}
 		if outRef != nil {
 			if err := glfstasks.FastSync(ctx, jc.Dst, union, *outRef); err != nil {

--- a/src/internal/wantdag/wantdag.go
+++ b/src/internal/wantdag/wantdag.go
@@ -24,9 +24,9 @@ func PrepareInput(ctx context.Context, dst cadata.PostExister, src cadata.Getter
 		if err := res.Err(); err != nil {
 			return nil, fmt.Errorf("upstream node %d errored: %v", in.Node, err)
 		}
-		ref, err := glfstasks.ParseGLFSRef(res.Data)
+		ref, err := glfstasks.ParseGLFSRef(res.Root)
 		if err != nil {
-			return nil, fmt.Errorf("cannot convert job output (%s) to GLFS Ref: %v", res.Data, err)
+			return nil, fmt.Errorf("cannot convert job output (%s) to GLFS Ref: %v", res.Root, err)
 		}
 		mode := InputFileMode
 		if ref.Type == glfs.TypeTree {

--- a/src/internal/wantsetup/wantsetup.go
+++ b/src/internal/wantsetup/wantsetup.go
@@ -40,7 +40,7 @@ func Install(ctx context.Context, jsys wantjob.System, outDir string, snippet st
 	if err := res.Err(); err != nil {
 		return err
 	}
-	ref, err := glfstasks.ParseGLFSRef(res.Data)
+	ref, err := glfstasks.ParseGLFSRef(res.Root)
 	if err != nil {
 		return err
 	}

--- a/src/want/job.go
+++ b/src/want/job.go
@@ -426,7 +426,7 @@ func (s *jobSystem) process(x *job) (retErr error) {
 	// if it was not originally computed, and the output is successful GLFS, then
 	// we need to Pull into the job's store.
 	if !original && res.ErrCode == 0 {
-		if err := x.dst.(*wantdb.DBStore).Pull(s.bgCtx, res.Data); err != nil {
+		if err := x.dst.(*wantdb.DBStore).Pull(s.bgCtx, res.Root); err != nil {
 			return err
 		}
 		if err := s.finishJob(s.bgCtx, x.id, res); err != nil {

--- a/src/want/job_test.go
+++ b/src/want/job_test.go
@@ -57,7 +57,7 @@ func TestJobStores(t *testing.T) {
 	res, s2, err := jsys.ViewResult(ctx, idx)
 	require.NoError(t, err)
 	require.NoError(t, res.Err())
-	ref, err := glfstasks.ParseGLFSRef(res.Data)
+	ref, err := glfstasks.ParseGLFSRef(res.Root)
 	require.NoError(t, err)
 	var count int
 	require.NoError(t, glfs.WalkRefs(ctx, s2, *ref, func(ref glfs.Ref) error { count++; return nil }))

--- a/src/want/task.go
+++ b/src/want/task.go
@@ -33,7 +33,8 @@ type QEMUConfig = qemuops.Config
 type ExecutorConfig struct {
 	QEMU QEMUConfig
 
-	GoDir string
+	GoRoot  string
+	GoState string
 }
 
 func NewExecutor(cfg ExecutorConfig) wantjob.Executor {
@@ -65,10 +66,13 @@ func newExecutor(cfg ExecutorConfig) *executor {
 				return qemuops.NewExecutor(cfg.QEMU), nil
 			},
 			"golang": func(jc wantjob.Ctx) (wantjob.Executor, error) {
-				if err := install(jc, goops.InstallSnippet(), cfg.GoDir); err != nil {
+				if err := install(jc, goops.InstallSnippet(), cfg.GoRoot); err != nil {
 					return nil, err
 				}
-				return goops.NewExecutor(cfg.GoDir), nil
+				if err := os.MkdirAll(cfg.GoState, 0o755); err != nil {
+					return nil, err
+				}
+				return goops.NewExecutor(cfg.GoRoot, cfg.GoState), nil
 			},
 		},
 	}

--- a/src/want/want.go
+++ b/src/want/want.go
@@ -52,7 +52,11 @@ func (s *System) logDir() string {
 	return filepath.Join(s.stateDir, "log")
 }
 
-func (s *System) goDir() string {
+func (s *System) goRoot() string {
+	return filepath.Join(s.stateDir, "goroot")
+}
+
+func (s *System) goState() string {
 	return filepath.Join(s.stateDir, "go")
 }
 
@@ -71,7 +75,8 @@ func (s *System) Init(ctx context.Context) error {
 			InstallDir: s.qemuDir(),
 			MemLimit:   int64(memory.TotalMemory()) / 2 * 3,
 		},
-		GoDir: s.goDir(),
+		GoRoot:  s.goRoot(),
+		GoState: s.goState(),
 	})
 	s.jobs = newJobSystem(s.db, s.logDir(), exec, numWorkers)
 	return nil

--- a/src/wantcmd/build.go
+++ b/src/wantcmd/build.go
@@ -47,10 +47,10 @@ var buildCmd = star.Command{
 			} else {
 				c.Printf("%s:\n", targ.DefinedIn)
 			}
-			if ref, err := glfstasks.ParseGLFSRef(tres.Data); err == nil {
+			if ref, err := glfstasks.ParseGLFSRef(tres.Root); err == nil {
 				c.Printf("  %v %v\n", tres.ErrCode, ref)
 			} else {
-				c.Printf("  %v %q\n", tres.ErrCode, tres.Data)
+				c.Printf("  %v %q\n", tres.ErrCode, tres.Root)
 			}
 		}
 		c.Printf("%v\n", dur)
@@ -241,7 +241,7 @@ var exportRepoCmd = star.Command{
 		for i, target := range res.Targets {
 			if target.IsStatement {
 				tres := res.TargetResults[i]
-				ref, err := glfstasks.ParseGLFSRef(tres.Data)
+				ref, err := glfstasks.ParseGLFSRef(tres.Root)
 				if err != nil {
 					return err
 				}

--- a/src/wantjob/jobs.go
+++ b/src/wantjob/jobs.go
@@ -92,27 +92,27 @@ const (
 // Jobs will also have results when cancelled or timed out, with the situation reflected in the ErrCode
 type Result struct {
 	ErrCode ErrCode `json:"ec"`
-	Data    []byte  `json:"d"`
+	Root    []byte  `json:"root"`
 	Schema  Schema  `json:"sch"`
 }
 
 func Success(schema Schema, data []byte) *Result {
-	return &Result{Schema: schema, Data: data}
+	return &Result{Schema: schema, Root: data}
 }
 
 func Result_ErrExec(err error) *Result {
-	return &Result{ErrCode: EXEC_ERROR, Data: []byte(err.Error())}
+	return &Result{ErrCode: EXEC_ERROR, Root: []byte(err.Error())}
 }
 
 func Result_ErrInternal(err error) *Result {
-	return &Result{ErrCode: INTERNAL_ERROR, Data: []byte(err.Error())}
+	return &Result{ErrCode: INTERNAL_ERROR, Root: []byte(err.Error())}
 }
 
 func (r *Result) Err() error {
 	if r.ErrCode == 0 {
 		return nil
 	}
-	return fmt.Errorf("job failed errcode=%v data=%s", r.ErrCode, r.Data)
+	return fmt.Errorf("job failed errcode=%v data=%s", r.ErrCode, r.Root)
 }
 
 type JobInfo struct {

--- a/src/wantjob/jobs.go
+++ b/src/wantjob/jobs.go
@@ -91,9 +91,9 @@ const (
 // Result is produced by finished jobs.
 // Jobs will also have results when cancelled or timed out, with the situation reflected in the ErrCode
 type Result struct {
-	ErrCode ErrCode `json:"ec"`
+	ErrCode ErrCode `json:"errcode"`
 	Root    []byte  `json:"root"`
-	Schema  Schema  `json:"sch"`
+	Schema  Schema  `json:"schema"`
 }
 
 func Success(schema Schema, data []byte) *Result {

--- a/src/wantjob/wanthttp/harness.go
+++ b/src/wantjob/wanthttp/harness.go
@@ -1,4 +1,4 @@
-package wantqemu
+package wanthttp
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	"go.brendoncarroll.net/state/cadata"
 	"wantbuild.io/want/src/internal/streammux"
 	"wantbuild.io/want/src/wantjob"
-	"wantbuild.io/want/src/wantjob/wanthttp"
 )
 
 // MainRW connects to a wanthttp API served on rw and calls fn with a job context for the server.
@@ -17,11 +16,11 @@ func MainRW(rw io.ReadWriter, fn func(jc wantjob.Ctx, s cadata.Getter, input []b
 	hc := &http.Client{
 		Transport: streammux.NewRoundTripper(mux),
 	}
-	wc := wanthttp.NewClient(hc, "")
+	wc := NewClient(hc, "")
 	jc := wantjob.Ctx{
 		Context: context.Background(),
 		System:  wc,
-		Dst:     wc.Store(wanthttp.CurrentStore),
+		Dst:     wc.Store(CurrentStore),
 	}
 	input, inputStore, err := wc.GetInput(context.Background())
 	if err != nil {

--- a/src/wantjob/wanthttp/server.go
+++ b/src/wantjob/wanthttp/server.go
@@ -50,8 +50,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/input":
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		w.WriteHeader(http.StatusOK)
-		w.Write(s.input)
+		if s.input == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("no input set, not in a job context"))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write(s.input)
+		}
 	case "/result":
 		handleRequest(w, r, func(ctx context.Context, req SetResultReq) (*SetResultResp, error) {
 			s.mu.Lock()

--- a/src/wantjob/wanthttp/wanthttp.go
+++ b/src/wantjob/wanthttp/wanthttp.go
@@ -2,10 +2,17 @@
 package wanthttp
 
 import (
+	"math"
+
 	"go.brendoncarroll.net/state/cadata"
 
 	"wantbuild.io/want/src/wantjob"
 )
+
+// CurrentStore is the store for the current job.
+const CurrentStore = StoreID(math.MaxUint32)
+
+type StoreID uint32
 
 type SpawnReq struct {
 	Task wantjob.Task `json:"task"`
@@ -41,7 +48,7 @@ type ViewResultReq struct {
 
 type ViewResultResp struct {
 	Result  wantjob.Result `json:"result"`
-	StoreID int            `json:"store_id"`
+	StoreID StoreID        `json:"store_id"`
 }
 
 type DeleteJobReq struct {
@@ -54,12 +61,6 @@ type ListJobsReq struct{}
 
 type ListJobsResp struct {
 	Idxs []wantjob.Idx `json:"idxs"`
-}
-
-type GetTaskReq struct{}
-
-type GetTaskResp struct {
-	Task *Task `json:"task"`
 }
 
 type SetResultReq struct {

--- a/src/wantjob/wanthttp/wanthttp_test.go
+++ b/src/wantjob/wanthttp/wanthttp_test.go
@@ -44,17 +44,14 @@ func TestJobsOnPipe(t *testing.T) {
 	})
 }
 
-func TestGetTask(t *testing.T) {
+func TestGetInput(t *testing.T) {
 	ctx := testutil.Context(t)
 	client, srv := setup(t)
-	srv.task = &Task{
-		Op:    "test",
-		Input: []byte("test"),
-	}
-	task, err := client.GetTask(ctx)
+	srv.input = []byte("test")
+	input, _, err := client.GetInput(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, task, srv.task)
+	require.Equal(t, input, srv.input)
 }
 
 func TestSetResult(t *testing.T) {
@@ -63,12 +60,12 @@ func TestSetResult(t *testing.T) {
 	client.SetResult(ctx, Result{
 		ErrCode: wantjob.OK,
 		Schema:  wantjob.Schema_NoRefs,
-		Data:    []byte("test"),
+		Root:    []byte("test"),
 	})
 	result := Result{
 		ErrCode: wantjob.OK,
 		Schema:  wantjob.Schema_NoRefs,
-		Data:    []byte("test"),
+		Root:    []byte("test"),
 	}
 	require.NoError(t, client.SetResult(ctx, result))
 	require.Equal(t, result, *srv.result)

--- a/src/wantjob/wantjobtests/job_tests.go
+++ b/src/wantjob/wantjobtests/job_tests.go
@@ -22,7 +22,6 @@ func TestJobs(t *testing.T, mksys func(t testing.TB, exec wantjob.Executor) want
 		res, _, err := wantjob.Do(ctx, sys, stores.NewVoid(), wantjob.Task{Op: "toUpper", Input: []byte("hello")})
 		require.NoError(t, err)
 		require.NoError(t, res.Err())
-		require.Equal(t, "HELLO", string(res.Data))
+		require.Equal(t, "HELLO", string(res.Root))
 	})
-
 }

--- a/src/wantqemu/harness.go
+++ b/src/wantqemu/harness.go
@@ -1,0 +1,34 @@
+package wantqemu
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"go.brendoncarroll.net/state/cadata"
+	"wantbuild.io/want/src/internal/streammux"
+	"wantbuild.io/want/src/wantjob"
+	"wantbuild.io/want/src/wantjob/wanthttp"
+)
+
+// MainRW connects to a wanthttp API served on rw and calls fn with a job context for the server.
+func MainRW(rw io.ReadWriter, fn func(jc wantjob.Ctx, s cadata.Getter, input []byte) wantjob.Result) {
+	mux := streammux.New(rw)
+	hc := &http.Client{
+		Transport: streammux.NewRoundTripper(mux),
+	}
+	wc := wanthttp.NewClient(hc, "")
+	jc := wantjob.Ctx{
+		Context: context.Background(),
+		System:  wc,
+		Dst:     wc.Store(wanthttp.CurrentStore),
+	}
+	input, inputStore, err := wc.GetInput(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	res := fn(jc, inputStore, input)
+	if err := wc.SetResult(context.Background(), res); err != nil {
+		panic(err)
+	}
+}

--- a/src/wantqemu/qemutasks.go
+++ b/src/wantqemu/qemutasks.go
@@ -20,10 +20,11 @@ type MicroVMTask struct {
 	Memory uint64
 
 	// Kernel is the linux kernel image used to boot the VM.
-	Kernel     glfs.Ref
-	KernelArgs string
-	Initrd     *glfs.Ref
-	VirtioFS   map[string]VirtioFSSpec
+	Kernel      glfs.Ref
+	KernelArgs  string
+	Initrd      *glfs.Ref
+	SerialPorts []SerialSpec
+	VirtioFS    map[string]VirtioFSSpec
 
 	Output Output
 }
@@ -36,6 +37,11 @@ func (t MicroVMTask) Validate() error {
 		}
 	}
 	return nil
+}
+
+type SerialSpec struct {
+	WantHTTP *struct{} `json:"wanthttp,omitempty"`
+	Console  *struct{} `jaon:"console,omitempty"`
 }
 
 type VirtioFSSpec struct {
@@ -53,7 +59,8 @@ type VirtioFSOutput struct {
 
 type Output struct {
 	// VirtioFS will read the output from a virtiofs filesystem
-	VirtioFS *VirtioFSOutput `json:"virtiofs,omitempty"`
+	VirtioFS  *VirtioFSOutput `json:"virtiofs,omitempty"`
+	JobOutput *struct{}       `json:"job,omitempty"`
 }
 
 func GrabVirtioFS(fsid string, q wantcfg.PathSet) Output {
@@ -62,11 +69,12 @@ func GrabVirtioFS(fsid string, q wantcfg.PathSet) Output {
 
 // microVMConfig is the config file for a MicroVMTask
 type microVMConfig struct {
-	Cores      uint32                  `json:"cores"`
-	Memory     uint64                  `json:"memory"`
-	KernelArgs string                  `json:"kernel_args"`
-	VirtioFS   map[string]VirtioFSSpec `json:"virtiofs"`
-	Output     Output                  `json:"output"`
+	Cores       uint32                  `json:"cores"`
+	Memory      uint64                  `json:"memory"`
+	KernelArgs  string                  `json:"kernel_args"`
+	SerialPorts []SerialSpec            `json:"serial_ports"`
+	VirtioFS    map[string]VirtioFSSpec `json:"virtiofs"`
+	Output      Output                  `json:"output"`
 }
 
 func PostMicroVMTask(ctx context.Context, s cadata.PostExister, x MicroVMTask) (*glfs.Ref, error) {

--- a/src/wantqemu/wantqemu_test.go
+++ b/src/wantqemu/wantqemu_test.go
@@ -7,6 +7,7 @@ import (
 
 	"wantbuild.io/want/src/internal/stores"
 	"wantbuild.io/want/src/internal/testutil"
+	"wantbuild.io/want/src/wantjob"
 )
 
 func TestPostGetMicroVMTask(t *testing.T) {
@@ -17,6 +18,10 @@ func TestPostGetMicroVMTask(t *testing.T) {
 		Cores:  1,
 		Memory: 1024 * 1e6,
 		Kernel: testutil.PostBlob(t, s, []byte("kernel bytes")),
+		SerialPorts: []SerialSpec{
+			{Console: &struct{}{}},
+			{WantHTTP: &struct{}{}},
+		},
 		VirtioFS: map[string]VirtioFSSpec{
 			"fs1": {
 				Writeable: true,
@@ -26,6 +31,14 @@ func TestPostGetMicroVMTask(t *testing.T) {
 					"c": []byte("3"),
 				}),
 			},
+		},
+
+		Input: Input{
+			Schema: wantjob.Schema_NoRefs,
+			Root:   []byte("hello world"),
+		},
+		Output: Output{
+			JobOutput: &struct{}{},
 		},
 	}
 


### PR DESCRIPTION
- Allows Want HTTP API to be served over a serial port inside a VM.
- Modify QEMU arguments so VMs work on Darwin.  Virtiofs still does not work.